### PR TITLE
fix: send DontHave for non-present CIDs

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -144,7 +144,7 @@ async function processEntry(entry, context) {
         await sendMessage(context, toSend)
       }
     } else if (newPresence) {
-      if (!context.message.addBlockPresence(newPresence, context.protocol)) {
+      if (context.message.addBlockPresence(newPresence, context.protocol)) {
         const toSend = context.message.encode(context.protocol)
         context.message = createEmptyMessage([], [newPresence])
         await sendMessage(context, toSend)


### PR DESCRIPTION
`addBlockPresence` returns `false` when the passed `presence` is _not_ added to the message because it got too big.

Currently the `presence` is only sent when this occurs and it should be the opposite.