### PR TITLE
fix: do not convert v0 to v1 CID

### DIFF
--- a/src/protocol.js
+++ b/src/protocol.js
@@ -94,7 +94,7 @@ class Entry {
     }
 
     return {
-      block: cid.toV1().bytes,
+      block: cid.bytes,
       priority,
       cancel,
       wantType,
@@ -179,12 +179,12 @@ class BlockPresence {
   }
 
   static fromRaw(raw, protocol) {
-    return new BlockPresence(CID.decode(raw.cid).toV1(), raw.type)
+    return new BlockPresence(CID.decode(raw.cid), raw.type)
   }
 
   serialize(protocol) {
     return {
-      cid: this.cid.toV1().bytes,
+      cid: this.cid.bytes,
       type: this.type
     }
   }


### PR DESCRIPTION
According to [this comment](https://github.com/ipfs/go-bitswap/blob/master/message/pb/message.proto#L16) the CID is v0 in bitswap v1.0 but v1 in v1.1 and v1.2. However, there's no code in go-bitswap that does this conversion:

* https://github.com/ipfs/go-bitswap/blob/35b5af95d30319094d448df61b7286b72a8c7b16/message/message.go#L118
* https://github.com/ipfs/go-bitswap/blob/35b5af95d30319094d448df61b7286b72a8c7b16/message/message.go#L455

I've also observed that ipfs-check thinks the peer does not respond when asked for a v0 CID. We receive a message from the remote peer but it ends up comparing a v0 CID with a v1 CID and eventually times out.

See https://github.com/aschmahmann/ipfs-check/blob/f4ba59752e733f6f9bb30647f6eeebbbb8b2062e/bitswap.go#L87-L118

I added some logging to ipfs-check to prove this and got the following output, and the response to the client times out:

```console
$ ./ipfs-check
listening on [::]:3333
Ready to start serving
Have you got this CID?: Qmf5iFqEsj9NVBBL3ZroEi2Jp9D882SkUDtTYWuGjxpRYe
Got result: {msg:0x1400cae2690 err:<nil>}
have: bafybeihyyl46sp5lbqca5q2khga5ywceiwxkzurztdelhyzgw4e6azmnkm
```

Note that `bafybeihyyl46sp5lbqca5q2khga5ywceiwxkzurztdelhyzgw4e6azmnkm` is the v1 version of `Qmf5iFqEsj9NVBBL3ZroEi2Jp9D882SkUDtTYWuGjxpRYe`:
https://cid.ipfs.io/#Qmf5iFqEsj9NVBBL3ZroEi2Jp9D882SkUDtTYWuGjxpRYe