### PR TITLE
fix: title on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AWS IPFS BitSwap peer
+# IPFS Elastic Provider Bitswap peer
 
 ## Deployment environment variables
 


### PR DESCRIPTION
For some reason this was not being recognised as a h1.

Also update with new name.