### PR TITLE
fix: catch emitted error on outgoing connection

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -77,6 +77,9 @@ async function sendMessage(context, encodedMessage) {
     const dialConnection = await context.service.dial(context.peer)
     const { stream } = await dialConnection.newStream(context.protocol)
     context.connection = new Connection(stream)
+    context.connection.on('error', error => {
+      logger.error({ error }, `Outgoing connection error: ${serializeError(error)}`)
+    })
   }
 
   context.connection.send(encodedMessage)


### PR DESCRIPTION
An 'error' listener is being attached on the incoming connection...but when sending the wantlist back to the peer with the wanted blocks no event listener is added to the outgoing connection.

I believe this is pulling the process down when there's an error in the outgoing connection.