### PR TITLE
feat: improve block not found message

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -115,7 +115,7 @@ async function processEntry(entry, context) {
       } else if (entry.sendDontHave && context.protocol === BITSWAP_V_120) {
         telemetry.increaseCount('bitswap-block-misses')
         newPresence = new BlockPresence(entry.cid, BlockPresence.Type.DontHave)
-        logger.warn({ entry }, `Block not found: ${entry.cid}`)
+        logger.warn({ entry, cid: entry.cid.toString() }, 'Block not found')
       }
     } else if (entry.wantType === Entry.WantType.Have && context.protocol === BITSWAP_V_120) {
       // Check if we have the block
@@ -127,7 +127,7 @@ async function processEntry(entry, context) {
       } else if (entry.sendDontHave) {
         telemetry.increaseCount('bitswap-block-misses')
         newPresence = new BlockPresence(entry.cid, BlockPresence.Type.DontHave)
-        logger.warn({ entry }, `Block not found: ${entry.cid}`)
+        logger.warn({ entry, cid: entry.cid.toString() }, 'Block not found')
       }
     }
 

--- a/src/service.js
+++ b/src/service.js
@@ -115,7 +115,7 @@ async function processEntry(entry, context) {
       } else if (entry.sendDontHave && context.protocol === BITSWAP_V_120) {
         telemetry.increaseCount('bitswap-block-misses')
         newPresence = new BlockPresence(entry.cid, BlockPresence.Type.DontHave)
-        logger.warn({ entry }, 'Block not found')
+        logger.warn({ entry }, `Block not found: ${entry.cid}`)
       }
     } else if (entry.wantType === Entry.WantType.Have && context.protocol === BITSWAP_V_120) {
       // Check if we have the block
@@ -127,7 +127,7 @@ async function processEntry(entry, context) {
       } else if (entry.sendDontHave) {
         telemetry.increaseCount('bitswap-block-misses')
         newPresence = new BlockPresence(entry.cid, BlockPresence.Type.DontHave)
-        logger.warn({ entry }, 'Block not found')
+        logger.warn({ entry }, `Block not found: ${entry.cid}`)
       }
     }
 


### PR DESCRIPTION
Would be useful to quickly know the CID of the block that was not found. The `entry` in the log does contain the CID but it is serialized as an object not a string so not super useful.

<img width="732" alt="Screenshot 2022-06-22 at 10 38 15" src="https://user-images.githubusercontent.com/152863/174997304-958f243b-af6d-40e0-8f45-de238b5c1f2d.png">
