### PR TITLE
Reduce log level when downloading peerId

### DIFF
--- a/src/peer-id.js
+++ b/src/peer-id.js
@@ -8,7 +8,7 @@ const { logger } = require('./logging')
 const { defaultDispatcher, fetchBlockFromS3 } = require('./storage')
 
 async function downloadPeerIdFile(dispatcher) {
-  logger.info(`Downloading PeerId from s3://${process.env.PEER_ID_S3_BUCKET}/${peerIdJsonFile}`)
+  logger.debug(`Downloading PeerId from s3://${process.env.PEER_ID_S3_BUCKET}/${peerIdJsonFile}`)
 
   const contents = await fetchBlockFromS3(
     dispatcher,


### PR DESCRIPTION
Readiness Probes are using this functionality, so logs can start looking like this:
(New line every 5s)
```
{"level":30,"time":"2022-06-24T18:02:27.018Z","msg":"Downloading PeerId from s3://us-west-2-staging-ep-bitswap-config/peerId.json"}
{"level":30,"time":"2022-06-24T18:02:32.018Z","msg":"Downloading PeerId from s3://us-west-2-staging-ep-bitswap-config/peerId.json"}
{"level":30,"time":"2022-06-24T18:02:37.018Z","msg":"Downloading PeerId from s3://us-west-2-staging-ep-bitswap-config/peerId.json"}
{"level":30,"time":"2022-06-24T18:02:42.018Z","msg":"Downloading PeerId from s3://us-west-2-staging-ep-bitswap-config/peerId.json"}
{"level":30,"time":"2022-06-24T18:02:47.018Z","msg":"Downloading PeerId from s3://us-west-2-staging-ep-bitswap-config/peerId.json"}
{"level":30,"time":"2022-06-24T18:02:52.018Z","msg":"Downloading PeerId from s3://us-west-2-staging-ep-bitswap-config/peerId.json"}
{"level":30,"time":"2022-06-24T18:02:57.018Z","msg":"Downloading PeerId from s3://us-west-2-staging-ep-bitswap-config/peerId.json"}
{"level":30,"time":"2022-06-24T18:03:02.018Z","msg":"Downloading PeerId from s3://us-west-2-staging-ep-bitswap-config/peerId.json"}
{"level":30,"time":"2022-06-24T18:03:07.019Z","msg":"Downloading PeerId from s3://us-west-2-staging-ep-bitswap-config/peerId.json"}
```