### PR TITLE
feat: announce multiaddr

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ _Variables in bold are required._
 | PEER_ID_DIRECTORY     | `/tmp`        | The directory of the file containing the BitSwap PeerID in JSON format.  |
 | PEER_ID_FILE          | `peerId.json` | The filename of the file containing the BitSwap PeerID in JSON format.   |
 | PEER_ID_S3_BUCKET     |               | The S3 bucket to download the BitSwap PeerID in JSON format.             |
+| PEER_ANNOUNCE_ADDR    |               | Swarm multiaddr to announce to the network (excluding peer ID).          |
 | PIPELINING            | `16`          | The maximum request to pipeline in a single HTTP connections in AWS.     |
 | PING_PERIOD_SECONDS   | `10`          | Wait interval for ping connected peer (Keep Alive)                       |
 | PORT                  | `3000`        | The port number to listen on.                                            |

--- a/src/config.js
+++ b/src/config.js
@@ -14,6 +14,7 @@ const {
   DYNAMO_CARS_TABLE: carsTable,
   PEER_ID_DIRECTORY: peerIdJsonDirectory,
   PEER_ID_FILE: peerIdJsonFile,
+  PEER_ANNOUNCE_ADDR: peerAnnounceAddr,
   PIPELINING: rawPipelining,
   PORT: rawPort,
   HTTP_PORT: rawHttpPort,
@@ -39,6 +40,7 @@ module.exports = {
   concurrency: !isNaN(concurrency) && concurrency > 0 ? concurrency : 128,
   peerIdJsonFile,
   peerIdJsonPath: join(peerIdJsonDirectory ?? '/tmp', peerIdJsonFile ?? 'peerId.json'),
+  peerAnnounceAddr,
   pipelining: !isNaN(pipelining) && pipelining > 0 ? pipelining : 16,
   port: !isNaN(port) && port > 0 ? port : 3000,
   primaryKeys: {

--- a/test/utils/helpers.js
+++ b/test/utils/helpers.js
@@ -55,7 +55,7 @@ async function prepare(t, protocol, dispatcher) {
     dispatcher = await mockAWS(t)
   }
 
-  const { service } = await startService(peerId, port, dispatcher)
+  const { service } = await startService({ peerId, currentPort: port, dispatcher })
   const { stream, receiver, node } = await createClient(peerId, port, protocol)
 
   const connection = new Connection(stream)


### PR DESCRIPTION
Currently `ipfs dht findpeer` for Elastic IPFS returns the addresses it is listening on. These are not the addresses we want folks to connect to!

This PR configures libp2p to announce a multiaddr provided in an env var `PEER_ANNOUNCE_ADDR`.

```
ipfs dht findpeer bafzbeibhqavlasjc7dvbiopygwncnrtvjd2xmryk5laib7zyjor6kf3avm 
/ip4/127.0.0.1/tcp/3000/ws
/ip4/10.0.1.128/tcp/3000/ws
```